### PR TITLE
Parser supports Ascii Song Command

### DIFF
--- a/data/todo_list.txt
+++ b/data/todo_list.txt
@@ -1,1 +1,2 @@
-
+twinkle aminor 123 [[UAs],[UA],[UAs],[UA],[UAs],[UA],[UAs],[UA]] [[UCs],[UC],[UC],[UC],[RTs],[RT],[RT],[RT]] 
+jingle aminor 123 

--- a/src/main/java/duke/Parser.java
+++ b/src/main/java/duke/Parser.java
@@ -1,6 +1,23 @@
 package duke;
 
-import duke.commands.*;
+
+import duke.commands.AddBarCommand;
+import duke.commands.AddCommand;
+import duke.commands.AddOverlayCommand;
+import duke.commands.ByeCommand;
+import duke.commands.Command;
+import duke.commands.CopyCommand;
+import duke.commands.DeleteBarCommand;
+import duke.commands.DeleteCommand;
+import duke.commands.DoneCommand;
+import duke.commands.EditCommand;
+import duke.commands.FindCommand;
+import duke.commands.GroupCommand;
+import duke.commands.HelpCommand;
+import duke.commands.ListCommand;
+import duke.commands.NewCommand;
+import duke.commands.ViewCommand;
+import duke.commands.AsciiCommand;
 
 
 /**
@@ -88,8 +105,8 @@ class Parser {
             }
             break;
         case "ascii":
-            if(message.length() >= 7){
-               return new AsciiCommand(message);
+            if (message.length() >= 7) {
+                return new AsciiCommand(message);
             }
             break;
         default:

--- a/src/main/java/duke/Parser.java
+++ b/src/main/java/duke/Parser.java
@@ -1,21 +1,6 @@
 package duke;
 
-import duke.commands.AddBarCommand;
-import duke.commands.AddCommand;
-import duke.commands.AddOverlayCommand;
-import duke.commands.ByeCommand;
-import duke.commands.Command;
-import duke.commands.CopyCommand;
-import duke.commands.DeleteBarCommand;
-import duke.commands.DeleteCommand;
-import duke.commands.DoneCommand;
-import duke.commands.EditCommand;
-import duke.commands.FindCommand;
-import duke.commands.GroupCommand;
-import duke.commands.HelpCommand;
-import duke.commands.ListCommand;
-import duke.commands.NewCommand;
-import duke.commands.ViewCommand;
+import duke.commands.*;
 
 
 /**
@@ -100,6 +85,11 @@ class Parser {
         case "copy":
             if (message.length() >= 6) {
                 return new CopyCommand(message);
+            }
+            break;
+        case "ascii":
+            if(message.length() >= 7){
+               return new AsciiCommand(message);
             }
             break;
         default:

--- a/src/main/java/duke/commands/AsciiCommand.java
+++ b/src/main/java/duke/commands/AsciiCommand.java
@@ -90,7 +90,7 @@ public class AsciiCommand extends Command<SongList> {
             throw new DukeException(message, "AsciiCommand");
         }
         return result;
-        
+
     }
 
     /**
@@ -200,13 +200,11 @@ public class AsciiCommand extends Command<SongList> {
         return songAscii;
     }
 
-
     private static ArrayList<ArrayList<String>> parseSongAscii(ArrayList<ArrayList<String>> rawSongAscii) {
         ArrayList<ArrayList<String>> resultAscii = new ArrayList<>();
         for (ArrayList<String> arr: rawSongAscii) {
             resultAscii.add(new ArrayList<>(arr));
         }
-
         for (int i = 0; i < 15; i++) {
             int length = rawSongAscii.get(i).size();
             if (i == 0 || i == 12) {

--- a/src/main/java/duke/commands/AsciiCommand.java
+++ b/src/main/java/duke/commands/AsciiCommand.java
@@ -151,17 +151,17 @@ public class AsciiCommand extends Command<SongList> {
             for (int j = 0; j < songAscii.get(i).size(); j++) {
                 if (j > 8 && (j - 1) % 8 == 0) {
                     if ((i > 2 && i < 12)) {
-                        System.out.print("|");
+                        //System.out.print("|");
                         stringResult.append("|");
                     } else {
-                        System.out.print(" ");
+                        //System.out.print(" ");
                         stringResult.append(" ");
                     }
                 }
-                System.out.print(songAscii.get(i).get(j));
+                //System.out.print(songAscii.get(i).get(j));
                 stringResult.append(songAscii.get(i).get(j));
             }
-            System.out.println();
+            //System.out.println();
             stringResult.append("\n");
         }
         return stringResult.toString();


### PR DESCRIPTION

View your song in ascii by using this command:
ascii song <song_name>

However, if there exist two songs with the same name in the songlist storage, this command will not work. Currently, two songs of the same name can exist in the song list (although it shouldn't be?). Let me know if you allow this.

Also, try out my command and let me know if there are bugs. Thank you!