### PR TITLE
Implement directory-based persistent storage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ javafx {
 
 shadowJar {
     archiveBaseName = "Ducats"
-    archiveVersion = "1.3"
+    archiveVersion = "1.3.1"
     archiveClassifier = null
     archiveAppendix = null
 }

--- a/data/helloworld.txt
+++ b/data/helloworld.txt
@@ -1,0 +1,3 @@
+helloworld c 130 
+[[RTs],[RT],[RT],[RT],[RT],[RT],[RT],[RT]]
+[[MCs],[MC],[MC],[MC],[MC],[MC],[MC],[MC]]

--- a/data/twinkle.txt
+++ b/data/twinkle.txt
@@ -1,0 +1,8 @@
+twinkle aminor 120 
+[[UAs],[UA],[UA],[UA],[RTs],[RT],[RT],[RT]]
+[[MCs],[MC],[MC],[MC],[MC],[MC],[LDs],[LD]]
+[[MCs],[MC],[MC],[MC],[MC],[MC],[LDs],[LD]]
+[[MCs],[UDs],[UD],[UD],[RTs],[RT],[RT],[RT]]
+[[MCs],[UDs],[UD],[UD],[RTs],[RT],[RT],[RT]]
+groups:
+goodstuff [[MCs],[MC],[MC],[MC],[MC],[MC],[LDs],[LD]] [[MCs],[UDs],[UD],[UD],[RTs],[RT],[RT],[RT]] 

--- a/src/main/java/ducats/Ducats.java
+++ b/src/main/java/ducats/Ducats.java
@@ -38,6 +38,8 @@ public class Ducats {
     private UndoRedoStack undoRedoStack;
     private Metronome metronome;
 
+    private String fileDelimiter = System.getProperty("file.separator");
+
     //@@author rohan-av
     /**
      * Constructor for the duke.Duke object, which initializes the UI, duke.TaskList and duke.Storage in
@@ -48,8 +50,7 @@ public class Ducats {
         songs = new SongList();
 
         //storage = new Storage(Paths.get("/home/rishi/Desktop/cs2113t/team/main/data/todo_list.txt"));
-        String fileDelimiter = System.getProperty("file.separator");
-        storage = new Storage(System.getProperty("user.dir") + fileDelimiter + "songlist.txt");
+        storage = new Storage(System.getProperty("user.dir") + fileDelimiter + "data");
 
         metronome = new Metronome();
         try {

--- a/src/main/java/ducats/Storage.java
+++ b/src/main/java/ducats/Storage.java
@@ -18,6 +18,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Scanner;
 
+//@@author rohan-av
 /**
  * A class to implement persistent storage of the task list using a .txt file.
  */
@@ -61,7 +62,6 @@ public class Storage {
     //
     // TODO: implement convertFromString
 
-    // @@author rohan-av
     private ArrayList<String> formatListToString(ArrayList<Song> list) {
         ArrayList<String> result = new ArrayList<>();
         for (Song song: list) {
@@ -70,6 +70,12 @@ public class Storage {
         return result;
     }
 
+    /**
+     * Takes in an ArrayList of Strings, each representing a song, and stores it in the .txt file.
+     *
+     * @param songs the ArrayList of songs as Strings
+     * @throws DucatsException in the case of IO exceptions
+     */
     private void writeStringsToFile(ArrayList<String> songs) throws DucatsException {
         FileWriter fileWriter;
         try {
@@ -86,6 +92,12 @@ public class Storage {
         }
     }
 
+    /**
+     * Returns an ArrayList of Strings, with each String corresponding to a line in the file.
+     *
+     * @return the lines as an ArrayList of Strings
+     * @throws DucatsException in the case of IO exceptions
+     */
     private ArrayList<String> readStringsFromFile() throws DucatsException {
         // reads file and returns an ArrayList of lines
         ArrayList<String> result = new ArrayList<>();
@@ -119,13 +131,13 @@ public class Storage {
         }
 
     }
-    /**
-     * A function that converts a string into a Song element.
-     *
-     * @param s - this is the string to be converted to a song.
-     */
 
     // twinkle [[UAs;UAs],[UA;UA],[UAs;UAs],[UA;UA],[UAs;UAs],[UA;UA],[UAs;UAs],[UA;UA]]
+    /**
+     * A function that converts a string into a Song object.
+     *
+     * @param s this is the string to be converted to a song.
+     */
     public Song convertSongFromString(String s) throws DucatsException {
         String[] sections = s.split(" ");
         if (sections.length == 1) {
@@ -225,193 +237,14 @@ public class Storage {
         return new Note(duration, pitch, isStart);
     }
 
-
+    /**
+     * Updates the .txt file with the current data found within the SongList.
+     *
+     * @param songList the SongList object containing the list of Song objects
+     * @throws DucatsException in the case of IO exceptions
+     */
     public void updateFile(SongList songList) throws DucatsException {
         // System.out.println(songList.getSongList().get(0).toString());
         writeStringsToFile(formatListToString(songList.getSongList()));
     }
-
-    // Ducats implementation ends here. (TODO: delete below when appropriate)
-
-    //    /**
-    //     * Returns an ArrayList of the String representations of all the duke.tasks.Task objects in the task list.
-    //     *
-    //     * @param list the task list containing all the duke.tasks.Task objects
-    //     * @return an ArrayList of the String representations of the tasks in the task list
-    //     */
-    //    private ArrayList<String> formatFile(ArrayList<Task> list) {
-    //        ArrayList<String> result = new ArrayList<>();
-    //        for (Task task : list) {
-    //            result.add(task.toString());
-    //        }
-    //        return result;
-    //    }
-    //
-    //    /**
-    //     * Writes the task list to the .txt file.
-    //     *
-    //     * @param tasks an ArrayList of the String representations of the tasks in the task list
-    //     * @throws DukeException in the case of input or output exceptions
-    //     */
-    //    private void writeFile(ArrayList<String> tasks) throws DukeException {
-    //        try {
-    //            Files.write(file, tasks, StandardCharsets.UTF_8);
-    //        } catch (IOException e) {
-    //            throw new DukeException("","io");
-    //        }
-    //    }
-    //
-    //    /**
-    //     * Reads the .txt fil and returns an ArrayList of Strings that represent the tasks in the task
-    //     * list
-    //     *
-    //     * @return an ArrayList of Strings that represent the tasks in the task list
-    //     * @throws DukeException in the case of input or output exceptions
-    //     */
-    //    private ArrayList<String> readFile() throws DukeException {
-    //        // reads file and returns an ArrayList of lines
-    //        ArrayList<String> result = new ArrayList<>();
-    //        try (BufferedReader br = Files.newBufferedReader(file)) {
-    //            String line;
-    //            while ((line = br.readLine()) != null) {
-    //                result.add(line);
-    //            }
-    //        } catch (Exception e) {
-    //            throw new DukeException("", "io");
-    //        }
-    //        return result;
-    //    }
-    //
-    //    /**
-    //     * After reading the file, converts each String representation back into its corresponding
-    //     * duke.tasks.Task object and pushes it into the duke.TaskList.
-    //     *
-    //     * @param taskList the duke.TaskList object used to store the task list
-    //     * @throws DukeException in the case of input or output exceptions
-    //     */
-    //    void loadList(TaskList taskList) throws DukeException {
-    //        // loads data into list
-    //        ArrayList<String> data = readFile();
-    //        for (String line: data) {
-    //            //System.out.println(line);
-    //            convertString(taskList, line);
-    //        }
-    //    }
-    //
-    //    /**
-    //     * Interprets the String, translates it to the appropriate duke.tasks.Task object, and adds it
-    //     * to the duke.TaskList.
-    //     *
-    //     * @param taskList the duke.TaskList object used to store the task list
-    //     * @param s the String representation to be converted
-    //     * @throws DukeException in the case of input or output exceptions
-    //     */
-    //    private void convertString(TaskList taskList, String s) throws DukeException {
-    //        try {
-    //            String type = s.substring(1,2); // T, D, E or A
-    //            boolean isDone = s.substring(4,5).equals("v");
-    //            String description;
-    //            String addendum;
-    //
-    //            switch (type) {
-    //            case "T":
-    //                description = s.substring(7);
-    //                ToDo todo = new ToDo(description);
-    //                if (isDone) {
-    //                    todo.setDone();
-    //                }
-    //                taskList.add(todo);
-    //                break;
-    //            case "E": {
-    //                String[] sections = s.substring(7).split("\\(from:");
-    //
-    //                sections[1] = sections[1].replace("to","-");
-    //                sections[1] = sections[1].replace(")","");
-    //                //System.out.println(sections[1]);
-    //                //description = sections[0].substring(0, sections[0].length() - 2);
-    //                //addendum = sections[1].substring(1, sections[1].length() - 1);
-    //                //String[] to_from  = addendum.split("to");
-    //
-    //                Event event = (Event)taskList.get_first_e(sections,1);
-    //                if (isDone) {
-    //                    event.setDone();
-    //                }
-    //                taskList.add(event);
-    //                break;
-    //            }
-    //            case "D": {
-    //                String[] sections = s.substring(7).split("by:");
-    //                description = sections[0].substring(0, sections[0].length() - 2);
-    //                addendum = sections[1].substring(1, sections[1].length() - 1);
-    //                Deadline deadline = new Deadline(description, addendum);
-    //                if (isDone) {
-    //                    deadline.setDone();
-    //                }
-    //                taskList.add(deadline);
-    //                break;
-    //            }
-    //            case "A": {
-    //                String[] sections = s.substring(7).split("after:");
-    //                description = sections[0].substring(0, sections[0].length() - 2);
-    //                addendum = sections[1].substring(6, sections[1].length() - 1);
-    //                int previousTaskNumber = Integer.parseInt(addendum);
-    //                DoAfter doAfter = new DoAfter(description, previousTaskNumber, taskList.getSize() + 1);
-    //                DoAfterList.add(previousTaskNumber);
-    //                if (isDone) {
-    //                    doAfter.setDone();
-    //                }
-    //                taskList.add(doAfter);
-    //                break;
-    //            }
-    //            case "B": {
-    //                String[] sections = s.substring(7).split("between");
-    //                description = sections[0].substring(0, sections[0].length() - 2);
-    //                String[] sections2 = sections[1].split("and");
-    //                String start = sections2[0].substring(1, sections2[0].length() - 1).trim();
-    //                String end = sections2[1].substring(0, sections2[1].length() - 1).trim();
-    //                BetweenTask betweenTask = new BetweenTask(description, start, end);
-    //                if (isDone) {
-    //                    betweenTask.setDone();
-    //                }
-    //                taskList.add(betweenTask);
-    //                break;
-    //            }
-    //            case "R": {
-    //                String[] sections = s.substring(7).split("\\(");
-    //                description = sections[0];
-    //                String frequency = sections[1].split(" ")[0];
-    //
-    //                String[] dateInfo = sections[1].split("on: ");
-    //                String[] dateNewInfo = dateInfo[1].split(" ");
-    //                String date = dateNewInfo[0];
-    //                String time;
-    //                if (dateNewInfo.length == 3) {
-    //                    time = dateNewInfo[2].substring(0, dateNewInfo[2].length() - 1);
-    //                } else {
-    //                    time = "";
-    //                }
-    //                //String date = "";
-    //                //       String time = "";
-    //                RecurringTask recurringTask = new RecurringTask(description, date, time, frequency);
-    //                taskList.add(recurringTask);
-    //                break;
-    //            }
-    //            default:
-    //                throw new DukeException("","io");
-    //            }
-    //
-    //        } catch (Exception e) {
-    //            throw new DukeException("","io");
-    //        }
-    //    }
-    //
-    //    /**
-    //     * Updates the .txt file with the latest task list found within the duke.Duke program.
-    //     *
-    //     * @param taskList the duke.TaskList object used to store the task list
-    //     * @throws DukeException in the case of input or output exceptions
-    //     */
-    //    public void updateFile(TaskList taskList) throws DukeException {
-    //        writeFile(formatFile(taskList.getTaskList()));
-    //    }
 }

--- a/src/main/java/ducats/components/Group.java
+++ b/src/main/java/ducats/components/Group.java
@@ -57,4 +57,17 @@ public class Group implements Serializable {
         return bars.get(i);
     }
 
+    /**
+     * Returns a String representation of the group to be used in persistent storage.
+     *
+     * @return a storage-friendly String representation of the group
+     */
+    public String toString() {
+        StringBuilder result = new StringBuilder();
+        result.append(name).append(" ");
+        for (Bar bar: bars) {
+            result.append(bar).append(" ");
+        }
+        return result.toString();
+    }
 }

--- a/src/main/java/ducats/components/Group.java
+++ b/src/main/java/ducats/components/Group.java
@@ -57,6 +57,7 @@ public class Group implements Serializable {
         return bars.get(i);
     }
 
+    //@@author rohan-av
     /**
      * Returns a String representation of the group to be used in persistent storage.
      *

--- a/src/main/java/ducats/components/Song.java
+++ b/src/main/java/ducats/components/Song.java
@@ -169,9 +169,9 @@ public class Song implements Serializable {
     //@@author rohan-av
 
     /**
-     * Returns a String representation of the Song to be used for persistent storage.
+     * Returns a one-line String representation of the song, meant for viewing in a list.
      *
-     * @return a storage-friendly String representation
+     * @return a one-line String representation of the song
      */
     public String toString() {
         StringBuilder result = new StringBuilder();
@@ -185,5 +185,37 @@ public class Song implements Serializable {
             result.append(bar.toString()).append(" ");
         }
         return result.toString();
+    }
+
+    /**
+     * Returns an ArrayList of Strings to be used in persistent storage in the form of a .txt file, with each element
+     * in the ArrayList corresponding to a line in the .txt file.
+     *
+     * @return a storage-friendly ArrayList of Strings to be used for storage in a .txt file
+     */
+    public ArrayList<String> toStringArrayList() {
+        ArrayList<String> result = new ArrayList<>();
+        StringBuilder attributes = new StringBuilder();
+        attributes.append(name)
+                .append(" ")
+                .append(key)
+                .append(" ")
+                .append(tempo)
+                .append(" ");
+        result.add(attributes.toString());
+        for (Bar bar: bars) {
+            result.add(bar.toString());
+        }
+        if (groups.size() > 0) {
+            result.add("groups:");
+            for (Group group: groups) {
+                result.add(group.toString());
+            }
+        }
+        return result;
+    }
+
+    public void addGroup(Group group) {
+        groups.add(group);
     }
 }

--- a/src/main/java/ducats/components/Song.java
+++ b/src/main/java/ducats/components/Song.java
@@ -167,7 +167,6 @@ public class Song implements Serializable {
     }
 
     //@@author rohan-av
-
     /**
      * Returns a one-line String representation of the song, meant for viewing in a list.
      *
@@ -215,6 +214,11 @@ public class Song implements Serializable {
         return result;
     }
 
+    /**
+     * Adds the provided Group to the Song.
+     *
+     * @param group the Group object to be added
+     */
     public void addGroup(Group group) {
         groups.add(group);
     }


### PR DESCRIPTION
Fixes #207

Moving from a single .txt file to a directory containing .txt files that each represent one song is perhaps the last major change to be made to Ducats. Other than fixing the problem of groups not being stored in persistant storage (#207), it also fixes the problems of there being a possible hard limit to song length (due to system-specific line length limits in .txt files), and enhances the user's experience if they were to edit specific songs.

Note that a natural consequence of this is that, upon startup, the songs in the SongList will be sorted in alphabetical order.

_A repeat of a prior PR due to its accidental closure._