### PR TITLE
Integrate Jacoco to check for test coverage

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,2 @@
+service_name: travis-pro
 repo_token: REPO_TOKEN

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: REPO_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,6 @@ deploy:
     on_success: always
     on_failure: never
     tags: true
+
+after_success:
+  - ./gradlew jacocoTestReport coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ before_deploy:
   - git config --local user.name "jwyf"
   - git config --local user.email "e0311252@u.nus.edu"
 
+env:
+  global:
+    - COVERALLS_REPO_TOKEN=REPO_TOKEN
+
 deploy:
   provider: releases
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,4 @@ deploy:
     tags: true
 
 after_success:
-  - ./gradlew jacocoTestReport coveralls
+  - ./gradlew test jacocoTestReport coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,5 +36,4 @@ deploy:
     tags: true
 
 after_success:
-  - curl -F 'json_file=@build/coveralls/report.json' 'https://coveralls.io/api/v1/jobs'
   - ./gradlew test jacocoTestReport coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,5 @@ deploy:
     tags: true
 
 after_success:
+  - curl -F 'json_file=@build/coveralls/report.json' 'https://coveralls.io/api/v1/jobs'
   - ./gradlew test jacocoTestReport coveralls

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,6 @@ jacocoTestReport {
 
 coveralls {
     jacocoReportPath 'build/reports/jacoco/test/jacocoTestReport.xml'
-    saveAsFile = true
-    sendToCoveralls = false
 }
 
 test.finalizedBy jacocoTestReport

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ jacocoTestReport {
 
 coveralls {
     jacocoReportPath 'build/reports/jacoco/test/jacocoTestReport.xml'
+    saveAsFile = true
+    sendToCoveralls = false
 }
 
 test.finalizedBy jacocoTestReport

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,9 @@ plugins {
     id 'application'
     id 'checkstyle'
     id 'org.openjfx.javafxplugin' version '0.0.7'
+    id 'jacoco'
+    id 'com.github.kt3k.coveralls' version '2.8.4'
 }
-
 
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.5.0'
@@ -14,6 +15,19 @@ dependencies {
 test {
     useJUnitPlatform()
 }
+
+jacocoTestReport {
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+}
+
+coveralls {
+    jacocoReportPath 'build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml'
+}
+
+test.finalizedBy jacocoTestReport
 
 group 'seedu.main'
 version '0.1.0'
@@ -36,6 +50,11 @@ shadowJar {
 
 checkstyle {
     toolVersion = '8.23'
+}
+
+jacoco {
+    toolVersion = "0.8.5"
+    reportsDir = file("$buildDir/reports/jacoco")
 }
 
 application {

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ jacocoTestReport {
 }
 
 coveralls {
-    jacocoReportPath 'build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml'
+    jacocoReportPath 'build/reports/jacoco/test/jacocoTestReport.xml'
 }
 
 test.finalizedBy jacocoTestReport

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+systemProp.jdk.tls.client.protocols="TLSv1,TLSv1.1,TLSv1.2"

--- a/src/main/java/ducats/StorageParser.java
+++ b/src/main/java/ducats/StorageParser.java
@@ -146,5 +146,4 @@ public class StorageParser {
     public ArrayList<String> getArrayList(Song song) {
         return song.toStringArrayList();
     }
-
 }


### PR DESCRIPTION
Also, an attempt was made to integrate Coveralls into Travis CI. However, this [issue](https://github.com/lemurheavy/coveralls-public/issues/632#issuecomment-465288723) was encountered. 

This probably arises from Coverall's webserver IPs being accidentally blacklisted by Travis, as mentioned. However, Coveralls is not necessary for the project, and simply just Jacoco can be used to determine coverage. 

Cheers, guys. Let's get that coverage up.